### PR TITLE
Seb/startup fixes

### DIFF
--- a/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
+++ b/dynamixel_hardware/include/dynamixel_hardware/dynamixel_hardware.hpp
@@ -68,6 +68,9 @@ public:
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
+  CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
+
+  DYNAMIXEL_HARDWARE_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 
   DYNAMIXEL_HARDWARE_PUBLIC
@@ -102,7 +105,7 @@ private:
   std::vector<Joint> joints_;
   std::vector<uint8_t> joint_ids_;
   bool torque_enabled_{false};
-  ControlMode control_mode_{ControlMode::Position};
+  ControlMode control_mode_{ControlMode::ExtendedPosition};
   bool mode_changed_{false};
   bool use_dummy_{false};
 };

--- a/dynamixel_hardware/src/dynamixel_hardware.cpp
+++ b/dynamixel_hardware/src/dynamixel_hardware.cpp
@@ -206,10 +206,6 @@ CallbackReturn DynamixelHardware::on_configure(const rclcpp_lifecycle::State & /
     return CallbackReturn::ERROR;
   }
 
-  // for (uint i = 0; i < joints_.size(); i++) {
-  //   RCLCPP_INFO(rclcpp::get_logger(kDynamixelHardware), "In on_configure, joint%d pos: %f", i, joints_[i].state.position);
-  // }
-
   enable_torque(false);
   set_control_mode(ControlMode::ExtendedPosition, true);
   set_joint_params();
@@ -285,7 +281,7 @@ return_type DynamixelHardware::read(const rclcpp::Time & /* time */, const rclcp
 
   if (!dynamixel_workbench_.syncRead(
         kPresentPositionVelocityCurrentIndex, ids.data(), ids.size(), &log)) {
-    RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "[in syncRead() in read()] %s", log);
+    RCLCPP_ERROR(rclcpp::get_logger(kDynamixelHardware), "%s", log);
     return return_type::ERROR;
   }
 


### PR DESCRIPTION
The on_configure() callback has been implemented, and most of the configuration relying on calls to dynamixel_workbench has been moved there.

Previously on_init() and on_activate() were used, which do not seem to be the correct places. In particular, read() and write() in the real time loop are already being called when on_activate() runs, which seemed to conflict with the deliberate read/write calls made when activating the controller, leading to startup failing or the initial state not being set correctly.

Note that the issue still exists for the enable_torque() function, which should ideally be in on_activate(), but is in on_configure() for now.